### PR TITLE
SAR-2662: update to pass partnership type down to the backend

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmGeneralPartnershipController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmGeneralPartnershipController.scala
@@ -70,10 +70,17 @@ class ConfirmGeneralPartnershipController @Inject()(val controllerComponents: Co
       (optVatNumber, optPartnershipUtr) match {
         case (Some(vatNumber), Some(partnershipUtr)) =>
           confirmPartnershipForm.bindFromRequest().fold(
-            error => Future.successful(BadRequest(confirm_partnership_utr(partnershipUtr, limitedPartnershipName = None, error, routes.ConfirmGeneralPartnershipController.submit())))
+            error => Future.successful(
+              BadRequest(confirm_partnership_utr(partnershipUtr, limitedPartnershipName = None, error, routes.ConfirmGeneralPartnershipController.submit()))
+            )
             , {
               case Yes =>
-                storePartnershipInformationService.storePartnershipInformation(vatNumber, partnershipUtr, companyNumber = None) flatMap {
+                storePartnershipInformationService.storePartnershipInformation(
+                  vatNumber = vatNumber,
+                  sautr = partnershipUtr,
+                  companyNumber = None,
+                  partnershipEntity = None
+                ) flatMap {
                   case Right(StorePartnershipInformationSuccess) =>
                     Future.successful(Redirect(principalRoutes.AgreeCaptureEmailController.show()))
                   case Left(_) =>

--- a/app/uk/gov/hmrc/vatsignupfrontend/models/BusinessEntity.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/models/BusinessEntity.scala
@@ -33,7 +33,13 @@ sealed trait BusinessEntity {
 
 object GeneralPartnership extends BusinessEntity
 
-object LimitedPartnership extends BusinessEntity
+trait LimitedPartnershipBase extends BusinessEntity
+
+object LimitedPartnership extends LimitedPartnershipBase
+
+object LimitedLiabilityPartnership extends LimitedPartnershipBase
+
+object ScottishLimitedPartnership extends LimitedPartnershipBase
 
 object LimitedCompany extends BusinessEntity
 
@@ -46,6 +52,8 @@ object BusinessEntity {
   val SoleTraderKey = "sole-trader"
   val GeneralPartnershipKey = "general-partnership"
   val LimitedPartnershipKey = "limited-partnership"
+  val LimitedLiabilityPartnershipKey = "llp"
+  val ScottishLimitedPartnershipKey = "scottish-partnership"
   val OtherKey = "other"
 
   implicit object BusinessEntitySessionFormatter extends SessionFormatter[BusinessEntity] {
@@ -54,6 +62,8 @@ object BusinessEntity {
       case SoleTraderKey => Some(SoleTrader)
       case GeneralPartnershipKey => Some(GeneralPartnership)
       case LimitedPartnershipKey => Some(LimitedPartnership)
+      case LimitedLiabilityPartnershipKey => Some(LimitedLiabilityPartnership)
+      case ScottishLimitedPartnershipKey => Some(ScottishLimitedPartnership)
       case OtherKey => Some(Other)
       case _ => None
     }
@@ -63,6 +73,8 @@ object BusinessEntity {
       case SoleTrader => SoleTraderKey
       case GeneralPartnership => GeneralPartnershipKey
       case LimitedPartnership => LimitedPartnershipKey
+      case LimitedLiabilityPartnership => LimitedLiabilityPartnershipKey
+      case ScottishLimitedPartnership => ScottishLimitedPartnershipKey
       case Other => OtherKey
     }
   }

--- a/app/uk/gov/hmrc/vatsignupfrontend/services/StorePartnershipInformationService.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/services/StorePartnershipInformationService.scala
@@ -17,25 +17,27 @@
 package uk.gov.hmrc.vatsignupfrontend.services
 
 import javax.inject.{Inject, Singleton}
-
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.vatsignupfrontend.connectors.StorePartnershipInformationConnector
 import uk.gov.hmrc.vatsignupfrontend.httpparsers.StorePartnershipInformationHttpParser.StorePartnershipInformationResponse
-import uk.gov.hmrc.vatsignupfrontend.models.PartnershipEntityType.{GeneralPartnership, LimitedPartnership}
+import uk.gov.hmrc.vatsignupfrontend.models.PartnershipEntityType.{CompanyTypeSessionFormatter, GeneralPartnership}
 
 import scala.concurrent.Future
 
 @Singleton
 class StorePartnershipInformationService @Inject()(storePartnershipInformationConnector: StorePartnershipInformationConnector) {
 
-  def storePartnershipInformation(vatNumber: String, sautr: String, companyNumber: Option[String]
+  def storePartnershipInformation(vatNumber: String,
+                                  sautr: String,
+                                  companyNumber: Option[String],
+                                  partnershipEntity: Option[String]
                                  )(implicit hc: HeaderCarrier): Future[StorePartnershipInformationResponse] =
     storePartnershipInformationConnector.storePartnershipInformation(
       vatNumber = vatNumber,
       sautr = sautr,
       partnershipType = companyNumber match {
-        case Some(_) => LimitedPartnership
-        case _ => GeneralPartnership
+        case None => GeneralPartnership
+        case Some(_) => CompanyTypeSessionFormatter.fromString(partnershipEntity.get).get
       },
       companyNumber = companyNumber
     )

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmLimitedPartnershipControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmLimitedPartnershipControllerISpec.scala
@@ -45,7 +45,8 @@ class ConfirmLimitedPartnershipControllerISpec extends ComponentSpecBase with Cu
           SessionKeys.partnershipSautrKey -> testSaUtr,
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNumberKey -> testCompanyNumber,
-          SessionKeys.companyNameKey -> testCompanyName
+          SessionKeys.companyNameKey -> testCompanyName,
+          SessionKeys.partnershipTypeKey -> testPartnershipType
         ))
 
       res should have(
@@ -77,7 +78,8 @@ class ConfirmLimitedPartnershipControllerISpec extends ComponentSpecBase with Cu
             SessionKeys.partnershipSautrKey -> testSaUtr,
             SessionKeys.vatNumberKey -> testVatNumber,
             SessionKeys.companyNumberKey -> testCompanyNumber,
-            SessionKeys.companyNameKey -> testCompanyName
+            SessionKeys.companyNameKey -> testCompanyName,
+            SessionKeys.partnershipTypeKey -> testPartnershipType
           ))(yesNo -> option_no)
 
         res should have(
@@ -96,7 +98,8 @@ class ConfirmLimitedPartnershipControllerISpec extends ComponentSpecBase with Cu
               SessionKeys.partnershipSautrKey -> testSaUtr,
               SessionKeys.vatNumberKey -> testVatNumber,
               SessionKeys.companyNumberKey -> testCompanyNumber,
-              SessionKeys.companyNameKey -> testCompanyName
+              SessionKeys.companyNameKey -> testCompanyName,
+              SessionKeys.partnershipTypeKey -> testPartnershipType
             ))(yesNo -> option_yes)
 
           res should have(
@@ -118,7 +121,8 @@ class ConfirmLimitedPartnershipControllerISpec extends ComponentSpecBase with Cu
           SessionKeys.partnershipSautrKey -> testSaUtr,
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNumberKey -> testCompanyNumber,
-          SessionKeys.companyNameKey -> testCompanyName
+          SessionKeys.companyNameKey -> testCompanyName,
+          SessionKeys.partnershipTypeKey -> testPartnershipType
         ))(yesNo -> option_yes)
 
       res should have(

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmPartnershipControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmPartnershipControllerISpec.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.vatsignupfrontend.controllers.principal.{routes => principalR
 import uk.gov.hmrc.vatsignupfrontend.helpers.IntegrationTestConstants._
 import uk.gov.hmrc.vatsignupfrontend.helpers.servicemocks.AuthStub._
 import uk.gov.hmrc.vatsignupfrontend.helpers.{ComponentSpecBase, CustomMatchers}
-import uk.gov.hmrc.vatsignupfrontend.models.PartnershipEntityType.LimitedPartnership
 
 class ConfirmPartnershipControllerISpec extends ComponentSpecBase with CustomMatchers {
 
@@ -59,8 +58,8 @@ class ConfirmPartnershipControllerISpec extends ComponentSpecBase with CustomMat
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNumberKey -> testCompanyNumber,
           SessionKeys.companyNameKey -> testCompanyName,
-          SessionKeys.partnershipTypeKey -> LimitedPartnership.toString)
-        )
+          SessionKeys.partnershipTypeKey -> testPartnershipType
+        ))
 
         res should have(
           httpStatus(OK)
@@ -74,8 +73,8 @@ class ConfirmPartnershipControllerISpec extends ComponentSpecBase with CustomMat
           val res = get("/confirm-partnership-company", Map(
             SessionKeys.companyNameKey -> testCompanyName,
             SessionKeys.companyNumberKey -> testCompanyNumber,
-            SessionKeys.partnershipTypeKey -> LimitedPartnership.toString)
-          )
+            SessionKeys.partnershipTypeKey -> testPartnershipType
+          ))
 
           res should have(
             httpStatus(SEE_OTHER),
@@ -91,8 +90,8 @@ class ConfirmPartnershipControllerISpec extends ComponentSpecBase with CustomMat
           val res = get("/confirm-partnership-company", Map(
             SessionKeys.companyNumberKey -> testCompanyNumber,
             SessionKeys.companyNameKey -> testCompanyName,
-            SessionKeys.partnershipTypeKey -> LimitedPartnership.toString)
-          )
+            SessionKeys.partnershipTypeKey -> testPartnershipType
+          ))
 
           res should have(
             httpStatus(SEE_OTHER),
@@ -127,7 +126,7 @@ class ConfirmPartnershipControllerISpec extends ComponentSpecBase with CustomMat
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNumberKey -> testCompanyNumber,
           SessionKeys.companyNameKey -> testCompanyName,
-          SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+          SessionKeys.partnershipTypeKey -> testPartnershipType
         ))()
 
       res should have(
@@ -147,7 +146,7 @@ class ConfirmPartnershipControllerISpec extends ComponentSpecBase with CustomMat
         Map(
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNumberKey -> testCompanyNumber,
-          SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+          SessionKeys.partnershipTypeKey -> testPartnershipType
         ))()
 
       res should have(

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ResolvePartnershipUtrControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ResolvePartnershipUtrControllerISpec.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.vatsignupfrontend.controllers.principal.partnerships
 import play.api.http.Status._
 import uk.gov.hmrc.vatsignupfrontend.SessionKeys
 import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.GeneralPartnershipJourney
+import uk.gov.hmrc.vatsignupfrontend.helpers.IntegrationTestConstants._
 import uk.gov.hmrc.vatsignupfrontend.helpers.servicemocks.AuthStub._
 import uk.gov.hmrc.vatsignupfrontend.helpers.{ComponentSpecBase, CustomMatchers}
-import uk.gov.hmrc.vatsignupfrontend.helpers.IntegrationTestConstants._
 
 class ResolvePartnershipUtrControllerISpec extends ComponentSpecBase with CustomMatchers {
 
@@ -49,10 +49,10 @@ class ResolvePartnershipUtrControllerISpec extends ComponentSpecBase with Custom
         "redirect to the confirm limited partnership page" in {
           stubAuth(OK, successfulAuthResponse(partnershipEnrolment))
 
-          val res = get("/resolve-partnership-utr",
-            Map(
-            SessionKeys.companyNumberKey->testCompanyNumber,
-            SessionKeys.companyNameKey->testCompanyName
+          val res = get("/resolve-partnership-utr", Map(
+            SessionKeys.companyNumberKey -> testCompanyNumber,
+            SessionKeys.companyNameKey -> testCompanyName,
+            SessionKeys.partnershipTypeKey -> testPartnershipType
           ))
 
           res should have(
@@ -65,10 +65,7 @@ class ResolvePartnershipUtrControllerISpec extends ComponentSpecBase with Custom
         "redirect to the confirm limited partnership page" in {
           stubAuth(OK, successfulAuthResponse(partnershipEnrolment))
 
-          val res = get("/resolve-partnership-utr",
-            Map(
-              SessionKeys.companyNumberKey->testCompanyNumber
-            ))
+          val res = get("/resolve-partnership-utr", Map(SessionKeys.companyNumberKey -> testCompanyNumber))
 
           res should have(
             httpStatus(SEE_OTHER),
@@ -80,10 +77,7 @@ class ResolvePartnershipUtrControllerISpec extends ComponentSpecBase with Custom
         "redirect to the confirm limited partnership page" in {
           stubAuth(OK, successfulAuthResponse(partnershipEnrolment))
 
-          val res = get("/resolve-partnership-utr",
-            Map(
-              SessionKeys.companyNameKey->testCompanyName
-            ))
+          val res = get("/resolve-partnership-utr", Map(SessionKeys.companyNameKey->testCompanyName))
 
           res should have(
             httpStatus(SEE_OTHER),

--- a/it/uk/gov/hmrc/vatsignupfrontend/helpers/IntegrationTestConstants.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/helpers/IntegrationTestConstants.scala
@@ -47,4 +47,5 @@ object IntegrationTestConstants {
   val testUserDetailsJson: String = Json.toJson(testUserDetails).toString()
   val testStartDate: LocalDate = LocalDate.now()
   val testEndDate: LocalDate = testStartDate.plusMonths(3)
+  val testPartnershipType: String = "limitedPartnership"
 }

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/CapturePartnershipCompanyNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/CapturePartnershipCompanyNumberControllerSpec.scala
@@ -28,7 +28,6 @@ import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.LimitedPartnershipJour
 import uk.gov.hmrc.vatsignupfrontend.config.mocks.MockControllerComponents
 import uk.gov.hmrc.vatsignupfrontend.forms.CompanyNumberForm._
 import uk.gov.hmrc.vatsignupfrontend.helpers.TestConstants._
-import uk.gov.hmrc.vatsignupfrontend.models.PartnershipEntityType
 import uk.gov.hmrc.vatsignupfrontend.models.companieshouse
 import uk.gov.hmrc.vatsignupfrontend.services.mocks.MockGetCompanyNameService
 
@@ -79,7 +78,7 @@ class CapturePartnershipCompanyNumberControllerSpec extends UnitSpec with GuiceO
         val result = TestCaptureCompanyNumberController.submit(request)
         status(result) shouldBe Status.SEE_OTHER
         redirectLocation(result) shouldBe Some(routes.ConfirmPartnershipController.show().url)
-        session(result) get SessionKeys.partnershipTypeKey should contain(PartnershipEntityType.LimitedPartnership.toString)
+        session(result) get SessionKeys.partnershipTypeKey should contain(testPartnershipType)
         session(result) get SessionKeys.companyNumberKey should contain(testCompanyNumber)
         session(result) get SessionKeys.companyNameKey should contain(testCompanyName)
       }

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmGeneralPartnershipControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmGeneralPartnershipControllerSpec.scala
@@ -96,7 +96,12 @@ class ConfirmGeneralPartnershipControllerSpec extends UnitSpec with GuiceOneAppP
       "User answered Yes" should {
         "go to the 'agree to receive emails' page" in {
           mockAuthAdminRole()
-          mockStorePartnershipInformation(testVatNumber, testSaUtr, companyNumber = None)(Future.successful(Right(StorePartnershipInformationSuccess)))
+          mockStorePartnershipInformation(
+            vatNumber = testVatNumber,
+            sautr = testSaUtr,
+            companyNumber = None,
+            partnershipEntity = None
+          )(Future.successful(Right(StorePartnershipInformationSuccess)))
 
           val result = TestConfirmGeneralPartnershipController.submit(testPostRequest().withSession(
             SessionKeys.vatNumberKey -> testVatNumber,
@@ -110,7 +115,12 @@ class ConfirmGeneralPartnershipControllerSpec extends UnitSpec with GuiceOneAppP
         // TOOD goto the error page once it's defined
         "throw internal server exception" in {
           mockAuthAdminRole()
-          mockStorePartnershipInformation(testVatNumber, testSaUtr, companyNumber = None)(Future.successful(Right(StorePartnershipInformationSuccess)))
+          mockStorePartnershipInformation(
+            vatNumber = testVatNumber,
+            sautr = testSaUtr,
+            companyNumber = None,
+            partnershipEntity = None
+          )(Future.successful(Right(StorePartnershipInformationSuccess)))
 
           val result = TestConfirmGeneralPartnershipController.submit(testPostRequest(No).withSession(
             SessionKeys.vatNumberKey -> testVatNumber,
@@ -127,7 +137,12 @@ class ConfirmGeneralPartnershipControllerSpec extends UnitSpec with GuiceOneAppP
   "vat number is in session but store partnership information is unsuccessful" should {
     "throw bad gateway exception" in {
       mockAuthAdminRole()
-      mockStorePartnershipInformation(testVatNumber, testSaUtr, companyNumber = None)(Future.successful(Left(StorePartnershipInformationFailureResponse(BAD_REQUEST))))
+      mockStorePartnershipInformation(
+        vatNumber = testVatNumber,
+        sautr = testSaUtr,
+        companyNumber = None,
+        partnershipEntity = None
+      )(Future.successful(Left(StorePartnershipInformationFailureResponse(BAD_REQUEST))))
 
       intercept[BadGatewayException] {
         await(TestConfirmGeneralPartnershipController.submit(testPostRequest().withSession(

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmPartnershipControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/partnerships/ConfirmPartnershipControllerSpec.scala
@@ -28,7 +28,6 @@ import uk.gov.hmrc.vatsignupfrontend.config.featureswitch._
 import uk.gov.hmrc.vatsignupfrontend.config.mocks.MockControllerComponents
 import uk.gov.hmrc.vatsignupfrontend.controllers.principal.{routes => principalRoutes}
 import uk.gov.hmrc.vatsignupfrontend.helpers.TestConstants._
-import uk.gov.hmrc.vatsignupfrontend.models.PartnershipEntityType.LimitedPartnership
 
 class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite with MockControllerComponents {
 
@@ -57,7 +56,7 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNumberKey -> testCompanyNumber,
           SessionKeys.companyNameKey -> testCompanyName,
-          SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+          SessionKeys.partnershipTypeKey -> testPartnershipType
         )
 
         val result = TestConfirmPartnershipController.show(request)
@@ -77,7 +76,7 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
         val request = testGetRequest.withSession(
           SessionKeys.companyNumberKey -> testCompanyNumber,
           SessionKeys.companyNameKey -> testCompanyName,
-          SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+          SessionKeys.partnershipTypeKey -> testPartnershipType
         )
 
         val result = TestConfirmPartnershipController.show(request)
@@ -93,7 +92,7 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
         val request = testPostRequest.withSession(
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNumberKey -> testCompanyNumber,
-          SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+          SessionKeys.partnershipTypeKey -> testPartnershipType
         )
 
         val result = TestConfirmPartnershipController.show(request)
@@ -110,7 +109,7 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
         val request = testPostRequest.withSession(
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNameKey -> testCompanyName,
-          SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+          SessionKeys.partnershipTypeKey -> testPartnershipType
         )
 
         val result = TestConfirmPartnershipController.show(request)
@@ -127,7 +126,6 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
           SessionKeys.vatNumberKey -> testVatNumber,
           SessionKeys.companyNumberKey -> testCompanyNumber,
           SessionKeys.companyNameKey -> testCompanyName
-
         )
 
         val result = TestConfirmPartnershipController.show(request)
@@ -145,7 +143,7 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
         SessionKeys.vatNumberKey -> testVatNumber,
         SessionKeys.companyNumberKey -> testCompanyNumber,
         SessionKeys.companyNameKey -> testCompanyName,
-        SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+        SessionKeys.partnershipTypeKey -> testPartnershipType
       )
 
       val result = TestConfirmPartnershipController.submit(request)
@@ -159,7 +157,7 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
       val request = testPostRequest.withSession(
         SessionKeys.companyNumberKey -> testCompanyNumber,
         SessionKeys.companyNameKey -> testCompanyName,
-        SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+        SessionKeys.partnershipTypeKey -> testPartnershipType
       )
 
       val result = TestConfirmPartnershipController.submit(request)
@@ -174,7 +172,7 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
       val request = testPostRequest.withSession(
         SessionKeys.vatNumberKey -> testVatNumber,
         SessionKeys.companyNameKey -> testCompanyName,
-        SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+        SessionKeys.partnershipTypeKey -> testPartnershipType
       )
 
       val result = TestConfirmPartnershipController.submit(request)
@@ -189,7 +187,7 @@ class ConfirmPartnershipControllerSpec extends UnitSpec with GuiceOneAppPerSuite
       val request = testPostRequest.withSession(
         SessionKeys.vatNumberKey -> testVatNumber,
         SessionKeys.companyNumberKey -> testCompanyNumber,
-        SessionKeys.partnershipTypeKey -> LimitedPartnership.toString
+        SessionKeys.partnershipTypeKey -> testPartnershipType
       )
 
       val result = TestConfirmPartnershipController.submit(request)

--- a/test/uk/gov/hmrc/vatsignupfrontend/helpers/TestConstants.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/helpers/TestConstants.scala
@@ -38,6 +38,7 @@ object TestConstants {
   val testNino: String = new Generator().nextNino.nino
   val testSaUtr: String = new Generator().nextAtedUtr.utr
   val testUri: String = "/test/uri"
+  val testPartnershipType: String = "limitedPartnership"
 
   val testAgentEnrolment: Enrolment = Enrolment(agentEnrolmentKey)
   val testVatDecEnrolment: Enrolment = Enrolment(VatDecEnrolmentKey) withIdentifier(VatReferenceKey, testVatNumber)

--- a/test/uk/gov/hmrc/vatsignupfrontend/services/StorePartnershipInformationServiceSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/services/StorePartnershipInformationServiceSpec.scala
@@ -66,6 +66,7 @@ class StorePartnershipInformationServiceSpec extends UnitSpec with MockitoSugar 
         val res = TestStorePartnershipInformationService.storePartnershipInformation(
           vatNumber = testVatNumber,
           sautr = testSaUtr,
+          partnershipEntity = Some(GeneralPartnership.StringValue),
           companyNumber = None
         )
 
@@ -85,6 +86,7 @@ class StorePartnershipInformationServiceSpec extends UnitSpec with MockitoSugar 
         val res = TestStorePartnershipInformationService.storePartnershipInformation(
           vatNumber = testVatNumber,
           sautr = testSaUtr,
+          partnershipEntity = Some(LimitedPartnership.StringValue),
           companyNumber = Some(testCompanyNumber)
         )
 

--- a/test/uk/gov/hmrc/vatsignupfrontend/services/mocks/MockStorePartnershipInformationService.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/services/mocks/MockStorePartnershipInformationService.scala
@@ -35,11 +35,15 @@ trait MockStorePartnershipInformationService extends BeforeAndAfterEach with Moc
     reset(mockStorePartnershipInformationService)
   }
 
-  def mockStorePartnershipInformation(vatNumber: String, sautr: String, companyNumber: Option[String])(returnValue: Future[StorePartnershipInformationResponse]): Unit = {
+  def mockStorePartnershipInformation(vatNumber: String,
+                                      sautr: String,
+                                      companyNumber: Option[String],
+                                      partnershipEntity: Option[String])(returnValue: Future[StorePartnershipInformationResponse]): Unit = {
     when(mockStorePartnershipInformationService.storePartnershipInformation(
       ArgumentMatchers.eq(vatNumber),
       ArgumentMatchers.eq(sautr),
-      ArgumentMatchers.eq(companyNumber)
+      ArgumentMatchers.eq(companyNumber),
+      ArgumentMatchers.eq(partnershipEntity)
     )(ArgumentMatchers.any()))
       .thenReturn(returnValue)
   }


### PR DESCRIPTION
Update service and controllers to support the entity type
Update partnership resolver to use the feature switches