### PR TITLE
SAR-3000: New resolver controller for unincorporated association

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/UnincorporatedAssociationResolverController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/UnincorporatedAssociationResolverController.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.http.InternalServerException
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys
+import uk.gov.hmrc.vatsignupfrontend.config.ControllerComponents
+import uk.gov.hmrc.vatsignupfrontend.config.auth.AdministratorRolePredicate
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.UnincorporatedAssociationJourney
+import uk.gov.hmrc.vatsignupfrontend.controllers.AuthenticatedController
+import uk.gov.hmrc.vatsignupfrontend.httpparsers.StoreUnincorporatedAssociationInformationHttpParser._
+import uk.gov.hmrc.vatsignupfrontend.services.StoreUnincorporatedAssociationInformationService
+
+import scala.concurrent.Future
+
+@Singleton
+class UnincorporatedAssociationResolverController @Inject()(val controllerComponents: ControllerComponents,
+                                                            storeUnincorporatedAssociationInformationService: StoreUnincorporatedAssociationInformationService
+                                                           )
+  extends AuthenticatedController(AdministratorRolePredicate, featureSwitches = Set(UnincorporatedAssociationJourney)) {
+
+  val resolve: Action[AnyContent] = Action.async { implicit request =>
+    authorised() {
+      val optVatNumber = request.session.get(SessionKeys.vatNumberKey).filter(_.nonEmpty)
+
+      optVatNumber match {
+        case Some(vatNumber) =>
+          storeUnincorporatedAssociationInformationService.storeUnincorporatedAssociationInformation(vatNumber = vatNumber) map {
+            case Right(StoreUnincorporatedAssociationInformationSuccess) =>
+              Redirect(routes.AgreeCaptureEmailController.show())
+            case Left(StoreUnincorporatedAssociationInformationFailureResponse(status)) =>
+              throw new InternalServerException("store unincorporated association information failed: status=" + status)
+          }
+        case _ =>
+          Future.successful(Redirect(routes.ResolveVatNumberController.resolve()))
+      }
+    }
+  }
+
+}

--- a/conf/principal.routes
+++ b/conf/principal.routes
@@ -197,6 +197,8 @@ GET         /vat-group-resolver                                 uk.gov.hmrc.vats
 # Sole trader resolver
 GET         /sole-trader-resolver                               uk.gov.hmrc.vatsignupfrontend.controllers.principal.soletrader.SoleTraderResolverController.resolve
 
-#Division Resolver
+# Division Resolver
 GET         /division-resolver                                  uk.gov.hmrc.vatsignupfrontend.controllers.principal.DivisionResolverController.resolve
 
+# Unincorporated Association resolver
+GET         /unincorporated-association-resolver                uk.gov.hmrc.vatsignupfrontend.controllers.principal.UnincorporatedAssociationResolverController.resolve

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/UnincorporatedAssociationResolverControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/UnincorporatedAssociationResolverControllerISpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import play.api.http.Status._
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.UnincorporatedAssociationJourney
+import uk.gov.hmrc.vatsignupfrontend.helpers.IntegrationTestConstants._
+import uk.gov.hmrc.vatsignupfrontend.helpers.servicemocks.AuthStub.{stubAuth, successfulAuthResponse}
+import uk.gov.hmrc.vatsignupfrontend.helpers.servicemocks.StoreUnincorporatedAssociationInformationStub._
+import uk.gov.hmrc.vatsignupfrontend.helpers.{ComponentSpecBase, CustomMatchers}
+
+class UnincorporatedAssociationResolverControllerISpec extends ComponentSpecBase with CustomMatchers {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    enable(UnincorporatedAssociationJourney)
+  }
+
+  "GET /unincorporated-association-resolver" when {
+    "the unincorporated association feature switch is on" when {
+      "store unincorporated association information returned NO_CONTENT" should {
+        "goto agree capture email" in {
+          stubAuth(OK, successfulAuthResponse())
+
+          stubStoreUnincorporatedAssociationInformation(testVatNumber)(NO_CONTENT)
+
+          val res = get("/unincorporated-association-resolver", Map(
+            SessionKeys.vatNumberKey -> testVatNumber
+          ))
+
+          res should have(
+            httpStatus(SEE_OTHER),
+            redirectUri(routes.AgreeCaptureEmailController.show().url)
+          )
+        }
+      }
+      "store unincorporated association information returned failure status" should {
+        "return INTERNAL_SERVER_ERROR" in {
+          stubAuth(OK, successfulAuthResponse())
+
+          stubStoreUnincorporatedAssociationInformation(testVatNumber)(INTERNAL_SERVER_ERROR)
+
+          val res = get("/unincorporated-association-resolver", Map(
+            SessionKeys.vatNumberKey -> testVatNumber
+          ))
+
+          res should have(
+            httpStatus(INTERNAL_SERVER_ERROR)
+          )
+        }
+      }
+      "there is no vat number in session" should {
+        "goto resolve vat number" in {
+          stubAuth(OK, successfulAuthResponse())
+
+          stubStoreUnincorporatedAssociationInformation(testVatNumber)(OK)
+
+          val res = get("/unincorporated-association-resolver")
+
+          res should have(
+            httpStatus(SEE_OTHER),
+            redirectUri(routes.ResolveVatNumberController.resolve().url)
+          )
+        }
+      }
+    }
+
+    "the unincorporated association feature switch is off" should {
+      "return NOT_FOUND" in {
+        disable(UnincorporatedAssociationJourney)
+
+        val res = get("/unincorporated-association-resolver")
+
+        res should have(
+          httpStatus(NOT_FOUND)
+        )
+      }
+    }
+  }
+
+}

--- a/it/uk/gov/hmrc/vatsignupfrontend/helpers/servicemocks/StoreUnincorporatedAssociationInformationStub.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/helpers/servicemocks/StoreUnincorporatedAssociationInformationStub.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.helpers.servicemocks
+
+object StoreUnincorporatedAssociationInformationStub extends WireMockMethods {
+  def stubStoreUnincorporatedAssociationInformation(vatNumber: String)(responseStatus: Int): Unit = {
+    when(method = POST, uri = s"/vat-sign-up/subscription-request/vat-number/$vatNumber/unincorporated-association")
+      .thenReturn(status = responseStatus)
+  }
+}

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/UnincorporatedAssociationResolverControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/UnincorporatedAssociationResolverControllerSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.{InternalServerException, NotFoundException}
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.UnincorporatedAssociationJourney
+import uk.gov.hmrc.vatsignupfrontend.config.mocks.MockControllerComponents
+import uk.gov.hmrc.vatsignupfrontend.helpers.TestConstants._
+import uk.gov.hmrc.vatsignupfrontend.httpparsers.StoreUnincorporatedAssociationInformationHttpParser._
+import uk.gov.hmrc.vatsignupfrontend.services.mocks.MockStoreUnincorporatedAssociationInformationService
+
+import scala.concurrent.Future
+
+class UnincorporatedAssociationResolverControllerSpec extends UnitSpec with GuiceOneAppPerSuite
+  with MockControllerComponents with MockStoreUnincorporatedAssociationInformationService {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    enable(UnincorporatedAssociationJourney)
+  }
+
+  object TestUnincorporatedAssociationResolverController extends UnincorporatedAssociationResolverController(
+    mockControllerComponents,
+    mockStoreUnincorporatedAssociationInformationService
+  )
+
+  lazy val testGetRequest = FakeRequest("GET", "/unincorporated-association-resolver")
+
+  "calling the resolve method on UnincorporatedAssociationResolverController" when {
+    "the unincorporated association feature switch is on" when {
+      "store unincorporated association information returns StoreUnincorporatedAssociationInformationSuccess" should {
+        "goto agree capture email" in {
+          mockAuthAdminRole()
+          mockStoreUnincorporatedAssociationInformation(testVatNumber)(
+            Future.successful(Right(StoreUnincorporatedAssociationInformationSuccess))
+          )
+
+          val res = await(TestUnincorporatedAssociationResolverController.resolve(testGetRequest.withSession(
+            SessionKeys.vatNumberKey -> testVatNumber
+          )))
+
+          status(res) shouldBe SEE_OTHER
+          redirectLocation(res) shouldBe Some(routes.AgreeCaptureEmailController.show().url)
+        }
+      }
+      "store unincorporated association information fails" should {
+        "throw internal server exception" in {
+          mockAuthAdminRole()
+          mockStoreUnincorporatedAssociationInformation(testVatNumber)(
+            Future.successful(Left(StoreUnincorporatedAssociationInformationFailureResponse(INTERNAL_SERVER_ERROR)))
+          )
+
+          intercept[InternalServerException] {
+            await(TestUnincorporatedAssociationResolverController.resolve(testGetRequest.withSession(
+              SessionKeys.vatNumberKey -> testVatNumber
+            )))
+          }
+        }
+      }
+      "vat number is not in session" should {
+        "goto resolve vat number" in {
+          mockAuthAdminRole()
+          mockStoreUnincorporatedAssociationInformation(testVatNumber)(Future.successful(Right(StoreUnincorporatedAssociationInformationSuccess)))
+
+          val res = await(TestUnincorporatedAssociationResolverController.resolve(testGetRequest))
+
+          status(res) shouldBe SEE_OTHER
+          redirectLocation(res) shouldBe Some(routes.ResolveVatNumberController.resolve().url)
+        }
+      }
+    }
+
+    "the unincorporated association feature switch is off" should {
+      "throw not found exception" in {
+        disable(UnincorporatedAssociationJourney)
+
+        intercept[NotFoundException] {
+          await(TestUnincorporatedAssociationResolverController.resolve(testGetRequest.withSession(
+            SessionKeys.vatNumberKey -> testVatNumber
+          )))
+        }
+      }
+    }
+  }
+
+}
+


### PR DESCRIPTION
New controller for the new entity type.
NOTE: the service and connector have been already added in a previous
user story.