### PR TITLE
SAR-3212: Enable non uk companies with uk establishment

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/forms/validation/utils/Patterns.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/forms/validation/utils/Patterns.scala
@@ -67,7 +67,7 @@ object Patterns {
       "NC", "R0", "NI", "EN",
       "IP", "SP", "IC", "SI",
       "NP", "NV", "RC", "SR",
-      "NR", "NO"
+      "NR", "NO", "BR"
     )
   }
 


### PR DESCRIPTION
/!\ WARNING: This will automatically enable an unspecified
             number of companies on live, as it is not feature
             switched. This should be OK because we believed
             these companies were enabled anyway.

- Add the BR prefix for CRN.
  The BR prefix is not currently in the companies house specification
  that we have, but it has been made specified that this is valid
  for every non uk company with uk establishment.