### PR TITLE
SAR-2844: New view for partnerships signing as limited companies

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/views/principal/partnership_as_company_error.scala.html
+++ b/app/uk/gov/hmrc/vatsignupfrontend/views/principal/partnership_as_company_error.scala.html
@@ -1,0 +1,41 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.play.views.html.helpers.form
+@import uk.gov.hmrc.vatsignupfrontend.config.AppConfig
+@import uk.gov.hmrc.vatsignupfrontend.views.html._
+@import uk.gov.hmrc.vatsignupfrontend.views.html.helpers.{continueButton, signOutLink}
+
+@(postAction: Call)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@principal_main_template(
+    title = Messages("principal.partnership_as_company_error.title"),
+    bodyClasses = None,
+    showSignOutLink = false
+) {
+
+    <h1 class="heading-large">@Messages("principal.partnership_as_company_error.heading")</h1>
+
+    <p>@Messages("principal.partnership_as_company_error.line_1")</p>
+
+    @form(action = postAction) {
+        <div class="form-group">
+            @continueButton(Some(Messages("base.try_again")))
+        </div>
+    }
+
+    @signOutLink(isAgent = false)
+}

--- a/conf/messages
+++ b/conf/messages
@@ -376,6 +376,11 @@ principal.could_not_confirm_business.title                             = We coul
 principal.could_not_confirm_business.heading                           = We could not confirm your business
 principal.could_not_confirm_business.line_1                            = The information you provided does not match the details we have about your business.
 
+# Partnership as company error
+principal.partnership_as_company_error.title                           = We could not confirm your business
+principal.partnership_as_company_error.heading                         = We could not confirm your business
+principal.partnership_as_company_error.line_1                          = The company number you entered is not for a limited company.
+
 # Cannot confirm business
 principal.bta.cannot_confirm_business.title                             = We cannot confirm the business
 principal.bta.cannot_confirm_business.heading                           = We cannot confirm the business

--- a/test/uk/gov/hmrc/vatsignupfrontend/assets/MessageLookup.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/assets/MessageLookup.scala
@@ -517,6 +517,13 @@ object MessageLookup {
     val tryAgain = "Try again"
   }
 
+  object PartnershipAsCompanyError {
+    val heading: String = "We could not confirm your business"
+    val title = heading + ServiceName.principalSuffix
+    val line1 = "The company number you entered is not for a limited company."
+    val tryAgain = "Try again"
+  }
+
   object BTACannotConfirmBusiness {
     val heading: String = "We cannot confirm the business"
     val title = heading + ServiceName.principalSuffix

--- a/test/uk/gov/hmrc/vatsignupfrontend/views/principal/partnerships/PrtnershipAsCompanyErrorSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/views/principal/partnerships/PrtnershipAsCompanyErrorSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.views.principal.partnerships
+
+import play.api.i18n.Messages.Implicits._
+import play.api.i18n.MessagesApi
+import play.api.test.FakeRequest
+import play.api.{Configuration, Environment}
+import uk.gov.hmrc.vatsignupfrontend.assets.MessageLookup.{PartnershipAsCompanyError => messages}
+import uk.gov.hmrc.vatsignupfrontend.config.AppConfig
+import uk.gov.hmrc.vatsignupfrontend.views.ViewSpec
+
+class PrtnershipAsCompanyErrorSpec extends ViewSpec {
+
+  val env = Environment.simple()
+  val configuration = Configuration.load(env)
+
+  lazy val messagesApi = app.injector.instanceOf[MessagesApi]
+
+  lazy val page = uk.gov.hmrc.vatsignupfrontend.views.html.principal.partnership_as_company_error(
+    postAction = testCall
+  )(FakeRequest(),
+    applicationMessages,
+    new AppConfig(configuration, env)
+  )
+
+  "The Partnership as Company error page" should {
+
+    val testPage = TestView(
+      name = "Partnership as company error View",
+      title = messages.title,
+      heading = messages.heading,
+      page = page,
+      haveSignOutInBanner = false
+    )
+
+    testPage.shouldHavePara(
+      messages.line1
+    )
+
+    testPage.shouldHaveForm("Could not find business Form")(actionCall = testCall)
+
+    testPage.shouldHaveSubmitButton(messages.tryAgain)
+
+    testPage.shouldHaveSignOutLink(isAgent = false)
+  }
+
+}
+


### PR DESCRIPTION
This new view for the individual side, is meant to stop users
from attempting multiple times to sign up a partnership while on
the limited company flow.