### PR TITLE
SAR-3196: CT Enrolment mismatch redirection

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/ConfirmCompanyController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/ConfirmCompanyController.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.vatsignupfrontend.SessionKeys._
 import uk.gov.hmrc.vatsignupfrontend.config.ControllerComponents
 import uk.gov.hmrc.vatsignupfrontend.config.auth.AdministratorRolePredicate
 import uk.gov.hmrc.vatsignupfrontend.controllers.AuthenticatedController
+import uk.gov.hmrc.vatsignupfrontend.httpparsers.StoreCompanyNumberHttpParser.CtReferenceMismatch
 import uk.gov.hmrc.vatsignupfrontend.services.StoreCompanyNumberService
 import uk.gov.hmrc.vatsignupfrontend.utils.EnrolmentUtils._
 import uk.gov.hmrc.vatsignupfrontend.views.html.principal.confirm_company
@@ -73,6 +74,8 @@ class ConfirmCompanyController @Inject()(val controllerComponents: ControllerCom
                   ) map {
                     case Right(_) =>
                       Redirect(routes.AgreeCaptureEmailController.show())
+                    case Left(CtReferenceMismatch) =>
+                      Redirect(routes.CtEnrolmentDetailsDoNotMatchController.show())
                     case Left(errResponse) =>
                       throw new InternalServerException("storeCompanyNumber failed: status=" + errResponse.status)
                   }

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/agent/ConfirmCompanyControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/agent/ConfirmCompanyControllerSpec.scala
@@ -90,6 +90,21 @@ class ConfirmCompanyControllerSpec extends UnitSpec with GuiceOneAppPerSuite wit
       redirectLocation(result) shouldBe Some(routes.EmailRoutingController.route().url)
     }
 
+    "go to the CT enrolment mismatch page" in {
+      mockAuthRetrieveAgentEnrolment()
+      mockStoreCompanyNumberCtMismatch(testVatNumber, testCompanyNumber, testCompanyUtr)
+
+      val request = testPostRequest.withSession(
+        SessionKeys.vatNumberKey -> testVatNumber,
+        SessionKeys.companyNumberKey -> testCompanyNumber
+      )
+
+      val result = TestConfirmCompanyController.show(testGetRequest)
+      status(result) shouldBe Status.SEE_OTHER
+      redirectLocation(result) shouldBe Some(routes.CaptureCompanyNumberController.show().url)
+    }
+
+
     "throw internal server exception if store company number fails" in {
       mockAuthRetrieveAgentEnrolment()
       mockStoreCompanyNumberFailure(testVatNumber, testCompanyNumber, companyUtr = None)


### PR DESCRIPTION
- The following change was made to capture the scenario when a user enters the principal flow with an IR-CT enrolment on their cred.
- Currently if there is a mismatch it goes to Tech Difficulties
- PR handles the CTReferenceMismatch on the enrolment and takes them to the CT enrolment mismatch error page