### PR TITLE
[VAT FE] Create new direct debit resolver controller

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
@@ -41,5 +41,5 @@ object SessionKeys {
   val previousVatReturnKey = "previousVatReturn"
   val lastReturnMonthPeriodKey = "lastReturnMonthPeriod"
   val box5FigureKey = "box5Figure"
-  val directDebitKey = ??? // TODO : To be confirmed
+  val directDebitKey = "directDebitResolver"
 }

--- a/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
@@ -41,5 +41,5 @@ object SessionKeys {
   val previousVatReturnKey = "previousVatReturn"
   val lastReturnMonthPeriodKey = "lastReturnMonthPeriod"
   val box5FigureKey = "box5Figure"
-  val directDebitKey = "directDebitResolver"
+  val directDebitKey = "hasDirectDebit"
 }

--- a/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
@@ -41,5 +41,5 @@ object SessionKeys {
   val previousVatReturnKey = "previousVatReturn"
   val lastReturnMonthPeriodKey = "lastReturnMonthPeriod"
   val box5FigureKey = "box5Figure"
-  val directDebitKey = "hasDirectDebitKey"
+  val hasDirectDebitKey = "hasDirectDebit"
 }

--- a/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
@@ -41,5 +41,5 @@ object SessionKeys {
   val previousVatReturnKey = "previousVatReturn"
   val lastReturnMonthPeriodKey = "lastReturnMonthPeriod"
   val box5FigureKey = "box5Figure"
-  val directDebitKey = "hasDirectDebit"
+  val directDebitKey = "hasDirectDebitKey"
 }

--- a/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
@@ -41,4 +41,5 @@ object SessionKeys {
   val previousVatReturnKey = "previousVatReturn"
   val lastReturnMonthPeriodKey = "lastReturnMonthPeriod"
   val box5FigureKey = "box5Figure"
+  val directDebitKey = ??? // TODO : To be confirmed
 }

--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverController.scala
@@ -18,31 +18,26 @@ package uk.gov.hmrc.vatsignupfrontend.controllers.principal
 
 import javax.inject.Inject
 import play.api.mvc.{Action, AnyContent}
-import uk.gov.hmrc.http.NotFoundException
 import uk.gov.hmrc.vatsignupfrontend.SessionKeys
 import uk.gov.hmrc.vatsignupfrontend.config.ControllerComponents
 import uk.gov.hmrc.vatsignupfrontend.config.auth.AdministratorRolePredicate
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.DirectDebitTermsJourney
 import uk.gov.hmrc.vatsignupfrontend.controllers.AuthenticatedController
 
 import scala.concurrent.Future
 
 class DirectDebitResolverController @Inject()(val controllerComponents: ControllerComponents)
   extends AuthenticatedController(
-    retrievalPredicate = AdministratorRolePredicate,
-    featureSwitches = Set(???)
-  ) {
+    retrievalPredicate = AdministratorRolePredicate) {
 
-  override protected def featureEnabled[T](func: => T): T =
-    if (featureSwitches exists isEnabled) func
-    else throw new NotFoundException(featureSwitchError)
-
-  def resolve: Action[AnyContent] = Action.async { implicit request =>
+  def show: Action[AnyContent] = Action.async { implicit request =>
     authorised() {
-      val directDebitFlag: Boolean = request.session.get(SessionKeys.directDebitKey).getOrElse("false").toBoolean
+      val directDebitFlagFromSession: Boolean = request.session.get(SessionKeys.directDebitKey).getOrElse("false").toBoolean
+      val directDebitFeatureSwitch: Boolean = isEnabled(DirectDebitTermsJourney)
 
-      if (directDebitFlag)
-        ??? // Not implemented
-      else Future.successful(Redirect(???)) // Email
+      if (directDebitFlagFromSession && directDebitFeatureSwitch)
+        Future.successful(???) // TODO: Not implemented
+      else Future.successful(Redirect(???)) // TODO: Email
     }
   }
 

--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverController.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import javax.inject.Inject
+import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.http.NotFoundException
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys
+import uk.gov.hmrc.vatsignupfrontend.config.ControllerComponents
+import uk.gov.hmrc.vatsignupfrontend.config.auth.AdministratorRolePredicate
+import uk.gov.hmrc.vatsignupfrontend.controllers.AuthenticatedController
+
+import scala.concurrent.Future
+
+class DirectDebitResolverController @Inject()(val controllerComponents: ControllerComponents)
+  extends AuthenticatedController(
+    retrievalPredicate = AdministratorRolePredicate,
+    featureSwitches = Set(???)
+  ) {
+
+  override protected def featureEnabled[T](func: => T): T =
+    if (featureSwitches exists isEnabled) func
+    else throw new NotFoundException(featureSwitchError)
+
+  def resolve: Action[AnyContent] = Action.async { implicit request =>
+    authorised() {
+      val directDebitFlag: Boolean = request.session.get(SessionKeys.directDebitKey).getOrElse("false").toBoolean
+
+      if (directDebitFlag)
+        ??? // Not implemented
+      else Future.successful(Redirect(???)) // Email
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverController.scala
@@ -36,8 +36,8 @@ class DirectDebitResolverController @Inject()(val controllerComponents: Controll
       val directDebitFeatureSwitch: Boolean = isEnabled(DirectDebitTermsJourney)
 
       if (directDebitFlagFromSession && directDebitFeatureSwitch)
-        Future.successful(???) // TODO: Not implemented
-      else Future.successful(Redirect(???)) // TODO: Email
+        Future.successful(NotImplemented) // TODO: Not implemented
+      else Future.successful(Redirect("")) // TODO: Email
     }
   }
 

--- a/conf/principal.routes
+++ b/conf/principal.routes
@@ -294,3 +294,6 @@ POST        /last-vat-return-date                               uk.gov.hmrc.vats
 # Capture Box Five Value page
 GET         /box-5-figure                                       uk.gov.hmrc.vatsignupfrontend.controllers.principal.CaptureBox5FigureController.show
 POST        /box-5-figure                                       uk.gov.hmrc.vatsignupfrontend.controllers.principal.CaptureBox5FigureController.submit
+
+# Direct Debit Resolver
+GET         /direct-debit-resolver                              uk.gov.hmrc.vatsignupfrontend.controllers.principal.DirectDebitResolverController.show

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerISpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import play.api.http.Status._
+import uk.gov.hmrc.vatsignupfrontend.helpers.servicemocks.AuthStub.{stubAuth, successfulAuthResponse}
+import uk.gov.hmrc.vatsignupfrontend.helpers.{ComponentSpecBase, CustomMatchers}
+
+class DirectDebitResolverControllerISpec extends ComponentSpecBase with CustomMatchers {
+
+  "GET TODO" should { // TODO: Once implementation for views has been completed, test can be adapted.
+    "return an OK" in {
+
+      stubAuth(OK, successfulAuthResponse())
+
+      val result = get("TODO")
+
+      result should have(httpStatus(OK))
+    }
+  }
+}

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerISpec.scala
@@ -17,19 +17,49 @@
 package uk.gov.hmrc.vatsignupfrontend.controllers.principal
 
 import play.api.http.Status._
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.DirectDebitTermsJourney
 import uk.gov.hmrc.vatsignupfrontend.helpers.servicemocks.AuthStub.{stubAuth, successfulAuthResponse}
 import uk.gov.hmrc.vatsignupfrontend.helpers.{ComponentSpecBase, CustomMatchers}
 
 class DirectDebitResolverControllerISpec extends ComponentSpecBase with CustomMatchers {
 
-  "GET TODO" should { // TODO: Once implementation for views has been completed, test can be adapted.
-    "return an OK" in {
+  "GET /direct-debit-resolver" should { // TODO: Once implementation for views has been completed, test can be adapted.
+    "return an 501 NotImplemented" in {
+
+      enable(DirectDebitTermsJourney)
 
       stubAuth(OK, successfulAuthResponse())
 
-      val result = get("TODO")
+      val result = get("/direct-debit-resolver",
+        Map(SessionKeys.directDebitKey -> "true")
+      )
 
-      result should have(httpStatus(OK))
+      result should have(httpStatus(NOT_IMPLEMENTED))
+    }
+
+    "return an 303 Redirect when the feature switch is disabled" in {
+
+      disable(DirectDebitTermsJourney)
+
+      stubAuth(OK, successfulAuthResponse())
+
+      val result = get("/direct-debit-resolver",
+        Map(SessionKeys.directDebitKey -> "true")
+      )
+
+      result should have(httpStatus(SEE_OTHER))
+    }
+
+    "return an 303 Redirect when the session flag is not in session" in {
+
+      enable(DirectDebitTermsJourney)
+
+      stubAuth(OK, successfulAuthResponse())
+
+      val result = get("/direct-debit-resolver")
+
+      result should have(httpStatus(SEE_OTHER))
     }
   }
 }

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerSpec.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.vatsignupfrontend.SessionKeys._
 import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.DirectDebitTermsJourney
 import uk.gov.hmrc.vatsignupfrontend.config.mocks.MockControllerComponents
+import play.api.http.Status.{NOT_IMPLEMENTED, SEE_OTHER}
 
 class DirectDebitResolverControllerSpec extends UnitSpec with GuiceOneAppPerSuite with MockControllerComponents {
 
@@ -31,7 +32,7 @@ class DirectDebitResolverControllerSpec extends UnitSpec with GuiceOneAppPerSuit
   private def sessionValues(directDebitFlag: Option[String]): Iterable[(String, String)] = directDebitFlag map(directDebitKey -> _)
 
   def testGetRequest(directDebitFlag: Option[String]): FakeRequest[AnyContentAsEmpty.type] = {
-    FakeRequest("GET", "")
+    FakeRequest("GET", "/direct-debit-resolver")
       .withSession(sessionValues(directDebitFlag).toSeq: _*)
   }
 
@@ -39,25 +40,25 @@ class DirectDebitResolverControllerSpec extends UnitSpec with GuiceOneAppPerSuit
     "all prerequisite data are in session" when {
       "the feature switch has been enabled show" should {
         "respond with Not Implemented" in { // TODO: Once implementation for views has been completed, test can be adapted.
-          mockAuthEmptyRetrieval()
+          mockAuthAdminRole()
           enable(DirectDebitTermsJourney)
 
           val result = TestDirectDebitResolverController.show(
             testGetRequest(directDebitFlag = Some("true")))
 
-          status(result) shouldBe ???
+          status(result) shouldBe NOT_IMPLEMENTED
         }
       }
 
       "the feature switch has been disabled" should {
         "redirect to the email template" in { // TODO: Once implementation for views has been completed, test can be adapted.
-          mockAuthEmptyRetrieval()
+          mockAuthAdminRole()
           disable(DirectDebitTermsJourney)
 
           val result = TestDirectDebitResolverController.show(
             testGetRequest(directDebitFlag = Some("true")))
 
-          status(result) shouldBe ???
+          status(result) shouldBe SEE_OTHER
         }
       }
     }
@@ -65,13 +66,13 @@ class DirectDebitResolverControllerSpec extends UnitSpec with GuiceOneAppPerSuit
     "prerequisite data are missing from session" when {
       "the feature switch has been enabled" should {
         "redirect to the email template" in { // TODO: Once implementation for views has been completed, test can be adapted.
-          mockAuthEmptyRetrieval()
+          mockAuthAdminRole()
           enable(DirectDebitTermsJourney)
 
           val result = TestDirectDebitResolverController.show(
             testGetRequest(directDebitFlag = None))
 
-          status(result) shouldBe ???
+          status(result) shouldBe SEE_OTHER
         }
       }
     }

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerSpec.scala
@@ -17,19 +17,63 @@
 package uk.gov.hmrc.vatsignupfrontend.controllers.principal
 
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys._
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.DirectDebitTermsJourney
 import uk.gov.hmrc.vatsignupfrontend.config.mocks.MockControllerComponents
 
 class DirectDebitResolverControllerSpec extends UnitSpec with GuiceOneAppPerSuite with MockControllerComponents {
 
-  object DirectDebitResolverController extends DirectDebitResolverController(mockControllerComponents)
+  object TestDirectDebitResolverController extends DirectDebitResolverController(mockControllerComponents)
 
-  lazy val testGetRequest = FakeRequest("", "")
+  private def sessionValues(directDebitFlag: Option[String]): Iterable[(String, String)] = directDebitFlag map(directDebitKey -> _)
 
-  "" should {
-    "" in {
+  def testGetRequest(directDebitFlag: Option[String]): FakeRequest[AnyContentAsEmpty.type] = {
+    FakeRequest("GET", "")
+      .withSession(sessionValues(directDebitFlag).toSeq: _*)
+  }
 
+  "Calling the show action of the Direct Debit Resolver controller" when {
+    "all prerequisite data are in session" when {
+      "the feature switch has been enabled show" should {
+        "respond with Not Implemented" in { // TODO: Once implementation for views has been completed, test can be adapted.
+          mockAuthEmptyRetrieval()
+          enable(DirectDebitTermsJourney)
+
+          val result = TestDirectDebitResolverController.show(
+            testGetRequest(directDebitFlag = Some("true")))
+
+          status(result) shouldBe ???
+        }
+      }
+
+      "the feature switch has been disabled" should {
+        "redirect to the email template" in { // TODO: Once implementation for views has been completed, test can be adapted.
+          mockAuthEmptyRetrieval()
+          disable(DirectDebitTermsJourney)
+
+          val result = TestDirectDebitResolverController.show(
+            testGetRequest(directDebitFlag = Some("true")))
+
+          status(result) shouldBe ???
+        }
+      }
+    }
+
+    "prerequisite data are missing from session" when {
+      "the feature switch has been enabled" should {
+        "redirect to the email template" in { // TODO: Once implementation for views has been completed, test can be adapted.
+          mockAuthEmptyRetrieval()
+          enable(DirectDebitTermsJourney)
+
+          val result = TestDirectDebitResolverController.show(
+            testGetRequest(directDebitFlag = None))
+
+          status(result) shouldBe ???
+        }
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitResolverControllerSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.test.FakeRequest
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.vatsignupfrontend.config.mocks.MockControllerComponents
+
+class DirectDebitResolverControllerSpec extends UnitSpec with GuiceOneAppPerSuite with MockControllerComponents {
+
+  object DirectDebitResolverController extends DirectDebitResolverController(mockControllerComponents)
+
+  lazy val testGetRequest = FakeRequest("", "")
+
+  "" should {
+    "" in {
+
+    }
+  }
+}


### PR DESCRIPTION
WIP => PR is to create the direct debit resolver controller with unit and integration tests. A large amount of the code is currently in an unimplemented state due to the requirement of the view implementation and reverse route implementation. Not implemented flags have been added as placeholders until actual implementation has been developed.