### PR TITLE
[SAR-3413] Added Controller for DD T&Cs Agree

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/SessionKeys.scala
@@ -41,4 +41,5 @@ object SessionKeys {
   val previousVatReturnKey = "previousVatReturn"
   val lastReturnMonthPeriodKey = "lastReturnMonthPeriod"
   val box5FigureKey = "box5Figure"
+  val acceptedDirectDebitTermsKey = "acceptedDirectDebitTerms"
 }

--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitTermsAndConditionsController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitTermsAndConditionsController.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys
+import uk.gov.hmrc.vatsignupfrontend.config.ControllerComponents
+import uk.gov.hmrc.vatsignupfrontend.config.auth.AdministratorRolePredicate
+import uk.gov.hmrc.vatsignupfrontend.controllers.AuthenticatedController
+import uk.gov.hmrc.vatsignupfrontend.views.html.principal.direct_debit_terms_and_conditions
+
+import scala.concurrent.Future
+
+@Singleton
+class DirectDebitTermsAndConditionsController @Inject()(val controllerComponents: ControllerComponents)
+  extends AuthenticatedController(AdministratorRolePredicate) {
+
+  val show: Action[AnyContent] = Action.async { implicit request =>
+    authorised() {
+      Future.successful(
+        Ok(direct_debit_terms_and_conditions(routes.DirectDebitTermsAndConditionsController.submit()))
+      )
+    }
+  }
+
+  val submit: Action[AnyContent] = Action.async { implicit request =>
+    authorised() {
+      Future.successful(
+        Redirect(routes.AgreeCaptureEmailController.show()).addingToSession(SessionKeys.acceptedDirectDebitTermsKey -> "true")
+      )
+    }
+  }
+}

--- a/app/uk/gov/hmrc/vatsignupfrontend/views/principal/direct_debit_terms_and_conditions.scala.html
+++ b/app/uk/gov/hmrc/vatsignupfrontend/views/principal/direct_debit_terms_and_conditions.scala.html
@@ -39,6 +39,5 @@
         </div>
     }
 
-    <!--TODO: Add reverse route to DD Not Agreed Controller once created -->
-    <p><a id="notAgreeLink" href="#">@Messages("principal.direct_debit_terms_and_conditions.not_agree_link")</a></p>
+    <p><a id="notAgreeLink" href="@routes.CancelDirectDebitController.show().url">@Messages("principal.direct_debit_terms_and_conditions.not_agree_link")</a></p>
 }

--- a/conf/principal.routes
+++ b/conf/principal.routes
@@ -297,3 +297,7 @@ POST        /box-5-figure                                       uk.gov.hmrc.vats
 
 ## Cancel direct debit page
 GET         /cancel-direct-debit                                uk.gov.hmrc.vatsignupfrontend.controllers.principal.CancelDirectDebitController.show
+
+# Direct Debit Terms and Conditions
+GET         /direct-debit-terms-and-conditions                  uk.gov.hmrc.vatsignupfrontend.controllers.principal.DirectDebitTermsAndConditionsController.show
+POST        /direct-debit-terms-and-conditions                  uk.gov.hmrc.vatsignupfrontend.controllers.principal.DirectDebitTermsAndConditionsController.submit

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitTermsAndConditionsControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitTermsAndConditionsControllerISpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import play.api.http.Status._
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys.acceptedDirectDebitTermsKey
+import uk.gov.hmrc.vatsignupfrontend.helpers.servicemocks.AuthStub._
+import uk.gov.hmrc.vatsignupfrontend.helpers.{ComponentSpecBase, CustomMatchers, SessionCookieCrumbler}
+
+class DirectDebitTermsAndConditionsControllerISpec extends ComponentSpecBase with CustomMatchers {
+
+  "GET /direct-debit-terms-and-conditions" should {
+
+    "return an OK" in {
+      stubAuth(OK, successfulAuthResponse())
+
+      val res = get("/direct-debit-terms-and-conditions")
+
+      res should have(
+        httpStatus(OK)
+      )
+    }
+  }
+
+  "POST /direct-debit-terms-and-conditions" should {
+
+    lazy val res = post("/direct-debit-terms-and-conditions")()
+
+    "return a redirect to Agree Capture Email" in {
+      stubAuth(OK, successfulAuthResponse())
+
+      res should have(
+        httpStatus(SEE_OTHER),
+        redirectUri(routes.AgreeCaptureEmailController.show().url)
+      )
+    }
+
+    "Add the acceptDirectDebitTermsKey to the session" in {
+      val session = SessionCookieCrumbler.getSessionMap(res)
+      session.keys should contain(acceptedDirectDebitTermsKey)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/vatsignupfrontend/assets/MessageLookup.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/assets/MessageLookup.scala
@@ -943,7 +943,7 @@ object MessageLookup {
     val buttonText = "Logout"
   }
 
-  object PrincipalTermsAndConditions {
+  object PrincipalDirectDebitTermsAndConditions {
     val heading = "Terms and Conditions"
     val title = heading + ServiceName.principalSuffix
     val link1 = "Direct Debit terms and conditions (opens in a new window or tab)"

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/ControllerSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers
+
+import org.jsoup.Jsoup
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.mvc.Result
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.vatsignupfrontend.config.mocks.MockControllerComponents
+import uk.gov.hmrc.vatsignupfrontend.utils.MaterializerSupport
+
+trait ControllerSpec extends UnitSpec with GuiceOneAppPerSuite with MockControllerComponents with MaterializerSupport {
+
+  def titleOf(result: Result): String = Jsoup.parse(bodyOf(result)).title
+
+}

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/ControllerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.vatsignupfrontend.controllers
 
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.mvc.Result
 import uk.gov.hmrc.play.test.UnitSpec
@@ -25,6 +26,7 @@ import uk.gov.hmrc.vatsignupfrontend.utils.MaterializerSupport
 
 trait ControllerSpec extends UnitSpec with GuiceOneAppPerSuite with MockControllerComponents with MaterializerSupport {
 
-  def titleOf(result: Result): String = Jsoup.parse(bodyOf(result)).title
+  def document(result: Result): Document = Jsoup.parse(bodyOf(result))
+  def titleOf(result: Result): String = document(result).title
 
 }

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitTermsAndConditionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/principal/DirectDebitTermsAndConditionsControllerSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.controllers.principal
+
+import play.api.http.Status
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.vatsignupfrontend.SessionKeys
+import uk.gov.hmrc.vatsignupfrontend.assets.MessageLookup
+import uk.gov.hmrc.vatsignupfrontend.controllers.ControllerSpec
+
+class DirectDebitTermsAndConditionsControllerSpec extends ControllerSpec {
+
+  object TestDirectDebitTermsAndConditionsController extends DirectDebitTermsAndConditionsController(mockControllerComponents)
+
+  lazy val testGetRequest = FakeRequest("GET", "/direct-debit-terms-and-conditions")
+  lazy val testPostRequest = FakeRequest("POST", "/direct-debit-terms-and-conditions")
+
+  "Calling the show action of the Direct Debit Terms and Conditions controller" should {
+
+    lazy val result = TestDirectDebitTermsAndConditionsController.show(testGetRequest)
+
+    "return status OK (200)" in {
+      mockAuthAdminRole()
+      status(result) shouldBe Status.OK
+    }
+
+    "return text/html as the content type" in {
+      contentType(result) shouldBe Some("text/html")
+    }
+
+    "have charset utf-8" in {
+      charset(result) shouldBe Some("utf-8")
+    }
+
+    "render the Direct Debit Terms and Conditions View" in {
+      titleOf(result) shouldBe MessageLookup.PrincipalDirectDebitTermsAndConditions.title
+    }
+  }
+
+  "Calling the submit action of the Direct Debit Terms and Conditions controller" should {
+
+    lazy val result = TestDirectDebitTermsAndConditionsController.submit(testPostRequest)
+
+    "return status SEE_OTHER (303)" in {
+      mockAuthAdminRole()
+      status(result) shouldBe Status.SEE_OTHER
+    }
+
+    s"have a redirectLocation to '${routes.AgreeCaptureEmailController.show().url}'" in {
+      redirectLocation(result) shouldBe Some(routes.AgreeCaptureEmailController.show().url)
+    }
+
+    "Add to session the SessionKey 'acceptedDirectDebitTermsKey' with value set to 'true'" in {
+      session(result).get(SessionKeys.acceptedDirectDebitTermsKey) shouldBe Some("true")
+    }
+  }
+}

--- a/test/uk/gov/hmrc/vatsignupfrontend/utils/MaterializerSupport.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/utils/MaterializerSupport.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignupfrontend.utils
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
+trait MaterializerSupport {
+  implicit val system = ActorSystem("Sys")
+  implicit val materializer = ActorMaterializer()
+}

--- a/test/uk/gov/hmrc/vatsignupfrontend/views/principal/DirectDebitTermsAndConditionsSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/views/principal/DirectDebitTermsAndConditionsSpec.scala
@@ -20,7 +20,7 @@ import play.api.i18n.Messages.Implicits._
 import play.api.i18n.MessagesApi
 import play.api.test.FakeRequest
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.vatsignupfrontend.assets.MessageLookup.{PrincipalTermsAndConditions => messages}
+import uk.gov.hmrc.vatsignupfrontend.assets.MessageLookup.{PrincipalDirectDebitTermsAndConditions => messages}
 import uk.gov.hmrc.vatsignupfrontend.config.AppConfig
 import uk.gov.hmrc.vatsignupfrontend.views.ViewSpec
 import uk.gov.hmrc.vatsignupfrontend.controllers.principal.routes

--- a/test/uk/gov/hmrc/vatsignupfrontend/views/principal/DirectDebitTermsAndConditionsSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/views/principal/DirectDebitTermsAndConditionsSpec.scala
@@ -23,6 +23,7 @@ import play.api.{Configuration, Environment}
 import uk.gov.hmrc.vatsignupfrontend.assets.MessageLookup.{PrincipalTermsAndConditions => messages}
 import uk.gov.hmrc.vatsignupfrontend.config.AppConfig
 import uk.gov.hmrc.vatsignupfrontend.views.ViewSpec
+import uk.gov.hmrc.vatsignupfrontend.controllers.principal.routes
 
 class DirectDebitTermsAndConditionsSpec extends ViewSpec {
 
@@ -55,13 +56,13 @@ class DirectDebitTermsAndConditionsSpec extends ViewSpec {
     testPage.shouldHaveALink(
       id = "termsAndConditionsLink",
       text = messages.link1,
-      href = "#" //TODO: Update with the Direct Debit Service url
+      href = "#" //TODO: Update with the Direct Debit Service T&Cs URL
     )
 
     testPage.shouldHaveALink(
       id = "notAgreeLink",
       text = messages.link2,
-      href = "#" //TODO: Update with the reverse route for the Do Not Agree Controller (Once Created)
+      href = routes.CancelDirectDebitController.show().url
     )
   }
 }


### PR DESCRIPTION
**Notes**:
  - SAR-3412 should be reviewed and merged prior to this. PR: #441 
  - Includes MaterializerSupport util to enable us to get the bodyOf result in the controller, parse using JSOUP and then check the title to confirm that the controller renders the correct view.
  - Created a ControllerSpec trait which includes common methods which can be mixed in to the Controller Unit Tests; currently has two methods: one for parsing to JSOUP and the other a helper to extract Title.