### PR TITLE
[SAR-3453] Updated routing for AgentEmailVerified view and ConfirmAgentEmailController

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/agent/AgentVerifiedEmailController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/agent/AgentVerifiedEmailController.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.vatsignupfrontend.config.ControllerComponents
 import uk.gov.hmrc.vatsignupfrontend.config.auth.AgentEnrolmentPredicate
-import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.{VerifyAgentEmail, VerifyClientEmail}
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.{ContactPreferencesJourney, VerifyAgentEmail, VerifyClientEmail}
 import uk.gov.hmrc.vatsignupfrontend.controllers.AuthenticatedController
 import uk.gov.hmrc.vatsignupfrontend.views.html.agent.agent_email_verified
 
@@ -32,12 +32,11 @@ class AgentVerifiedEmailController @Inject()(val controllerComponents: Controlle
 
   val show: Action[AnyContent] = Action.async { implicit request =>
     authorised() {
-      val continueLink = if(isEnabled(VerifyClientEmail)) routes.AgreeCaptureClientEmailController.show().url
+      val continueLink = if(isEnabled(ContactPreferencesJourney)) routes.ContactPreferenceController.show().url
+      else if(isEnabled(VerifyClientEmail)) routes.AgreeCaptureClientEmailController.show().url
       else routes.TermsController.show().url
 
-      Future.successful(
-        Ok(agent_email_verified(continueLink))
-      )
+      Future.successful(Ok(agent_email_verified(continueLink)))
     }
   }
 

--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/agent/ConfirmAgentEmailController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/agent/ConfirmAgentEmailController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.http.InternalServerException
 import uk.gov.hmrc.vatsignupfrontend.SessionKeys
 import uk.gov.hmrc.vatsignupfrontend.config.ControllerComponents
 import uk.gov.hmrc.vatsignupfrontend.config.auth.AgentEnrolmentPredicate
-import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.{VerifyAgentEmail, VerifyClientEmail}
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.{ContactPreferencesJourney, VerifyAgentEmail, VerifyClientEmail}
 import uk.gov.hmrc.vatsignupfrontend.controllers.AuthenticatedController
 import uk.gov.hmrc.vatsignupfrontend.httpparsers.StoreEmailAddressHttpParser.StoreEmailAddressSuccess
 import uk.gov.hmrc.vatsignupfrontend.services.StoreEmailAddressService
@@ -67,7 +67,9 @@ class ConfirmAgentEmailController @Inject()(val controllerComponents: Controller
           storeEmailAddressService.storeTransactionEmailAddress(vatNumber, transactionEmail) map {
             case Right(StoreEmailAddressSuccess(false)) =>
               Redirect(routes.VerifyAgentEmailController.show().url)
-            case Right(StoreEmailAddressSuccess(true)) if (isEnabled(VerifyClientEmail)) =>
+            case Right(StoreEmailAddressSuccess(true)) if isEnabled(ContactPreferencesJourney) =>
+              Redirect(routes.ContactPreferenceController.show().url)
+            case Right(StoreEmailAddressSuccess(true)) if isEnabled(VerifyClientEmail) =>
               Redirect(routes.AgreeCaptureClientEmailController.show().url)
             case Right(StoreEmailAddressSuccess(true)) =>
               Redirect(routes.TermsController.show().url)

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/agent/AgentVerifiedEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/agent/AgentVerifiedEmailControllerSpec.scala
@@ -21,7 +21,7 @@ import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.UnitSpec
-import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.{VerifyAgentEmail, VerifyClientEmail}
+import uk.gov.hmrc.vatsignupfrontend.config.featureswitch.{ContactPreferencesJourney, VerifyAgentEmail, VerifyClientEmail}
 import uk.gov.hmrc.vatsignupfrontend.config.mocks.MockControllerComponents
 import uk.gov.hmrc.vatsignupfrontend.views.html.agent.agent_email_verified
 import play.api.i18n.Messages.Implicits._
@@ -57,6 +57,17 @@ class AgentVerifiedEmailControllerSpec extends UnitSpec with GuiceOneAppPerSuite
         contentAsString(result) shouldBe agent_email_verified(routes.AgreeCaptureClientEmailController.show().url).body
       }
     }
-    }
+    "the contact preference feature switch is enabled" should {
+      "go to the Agent email Verified page with a link to the Contact Preferences page" in {
+        enable(VerifyAgentEmail)
+        enable(ContactPreferencesJourney)
 
+        mockAuthRetrieveAgentEnrolment()
+        val result = await(TestAgentVerifiedEmailController.show(testGetRequest))
+
+        status(result) shouldBe Status.OK
+        contentAsString(result) shouldBe agent_email_verified(routes.ContactPreferenceController.show().url).body
+      }
+    }
+  }
 }


### PR DESCRIPTION
AgentEmailVerifiedController ---> ContactPreferencesController _(if CP Journey enabled)_
ConfirmAgentEmailController ---> ContactPreferencesController _(if already verified and CP Journey enabled)_

**Note**: #464 for `SAR-3426` should be merged prior to this PR