### PR TITLE
SAR-3625 - Skip entering email, if agent email in session.

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/agent/CaptureAgentEmailController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/agent/CaptureAgentEmailController.scala
@@ -35,10 +35,21 @@ class CaptureAgentEmailController @Inject()(val controllerComponents: Controller
 
   val show: Action[AnyContent] = Action.async { implicit request =>
     authorised() {
-      Future.successful(
-        Ok(capture_agent_email(validateEmailForm.form, routes.CaptureAgentEmailController.submit()))
-      )
+      request.session.get(SessionKeys.transactionEmailKey) match {
+        case None => Future.successful(
+          Ok(capture_agent_email(validateEmailForm.form, routes.CaptureAgentEmailController.submit()))
+        )
+        case Some(_) => Future.successful(
+          Redirect(routes.ConfirmAgentEmailController.show())
+        )
+      }
     }
+  }
+
+  val change: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(
+      Redirect(routes.CaptureAgentEmailController.show())
+    ).removeSessionKey(SessionKeys.transactionEmailKey)
   }
 
   val submit: Action[AnyContent] = Action.async { implicit request =>

--- a/app/uk/gov/hmrc/vatsignupfrontend/views/agent/confirm_agent_email.scala.html
+++ b/app/uk/gov/hmrc/vatsignupfrontend/views/agent/confirm_agent_email.scala.html
@@ -32,5 +32,5 @@
             @continueButton(Some(Messages("base.confirm")))
         </div>
     }
-    <p><a id="changeLink" href="@uk.gov.hmrc.vatsignupfrontend.controllers.agent.routes.CaptureAgentEmailController.show().url">@Messages("agent.confirm_agent_email.link")</a></p>
+    <p><a id="changeLink" href="@uk.gov.hmrc.vatsignupfrontend.controllers.agent.routes.CaptureAgentEmailController.change().url">@Messages("agent.confirm_agent_email.link")</a></p>
 }

--- a/conf/agent.routes
+++ b/conf/agent.routes
@@ -74,6 +74,7 @@ POST        /client-email-address                               uk.gov.hmrc.vats
 
 #Capture Agent Email
 GET         /email-address                                      uk.gov.hmrc.vatsignupfrontend.controllers.agent.CaptureAgentEmailController.show
+GET         /email-address-change                               uk.gov.hmrc.vatsignupfrontend.controllers.agent.CaptureAgentEmailController.change
 POST        /email-address                                      uk.gov.hmrc.vatsignupfrontend.controllers.agent.CaptureAgentEmailController.submit
 
 #Confirm Email

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/agent/CaptureAgentEmailControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/agent/CaptureAgentEmailControllerISpec.scala
@@ -25,6 +25,8 @@ import uk.gov.hmrc.vatsignupfrontend.helpers.{ComponentSpecBase, CustomMatchers,
 
 class CaptureAgentEmailControllerISpec extends ComponentSpecBase with CustomMatchers {
 
+
+
   "GET /email-address" should {
     "return an OK" in {
       stubAuth(OK, successfulAuthResponse(agentEnrolment))
@@ -33,6 +35,18 @@ class CaptureAgentEmailControllerISpec extends ComponentSpecBase with CustomMatc
 
       res should have(
         httpStatus(OK)
+      )
+    }
+  }
+
+  "GET /email-address-change" should {
+    "return an OK" in {
+      stubAuth(OK, successfulAuthResponse(agentEnrolment))
+
+      val res = get("/client/email-address-change")
+
+      res should have(
+        httpStatus(SEE_OTHER)
       )
     }
   }

--- a/test/uk/gov/hmrc/vatsignupfrontend/controllers/agent/CaptureAgentEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/controllers/agent/CaptureAgentEmailControllerSpec.scala
@@ -36,7 +36,7 @@ class CaptureAgentEmailControllerSpec extends UnitSpec with GuiceOneAppPerSuite 
   def testPostRequest(emailAddress: String): FakeRequest[AnyContentAsFormUrlEncoded] =
     FakeRequest("POST", "/your-email-address").withFormUrlEncodedBody(email -> emailAddress)
 
-  "Calling the show action of the Capture Agent Email controller" should {
+  "Calling the show action of the Capture Agent Email controller without a submitted Email" should {
     "go to the Capture Agent Email page" in {
       mockAuthRetrieveAgentEnrolment()
 
@@ -45,6 +45,42 @@ class CaptureAgentEmailControllerSpec extends UnitSpec with GuiceOneAppPerSuite 
       status(result) shouldBe Status.OK
       contentType(result) shouldBe Some("text/html")
       charset(result) shouldBe Some("utf-8")
+    }
+  }
+
+  "Calling the show action of the Capture Agent Email controller with a submitted Email" should {
+    "go to the Capture Agent Email page" in {
+      mockAuthRetrieveAgentEnrolment()
+
+      val result = TestCaptureAgentEmailController.show(testGetRequest.withSession(SessionKeys.transactionEmailKey -> "test@test.com"))
+
+      status(result) shouldBe Status.SEE_OTHER
+      redirectLocation(result) shouldBe Some(routes.ConfirmAgentEmailController.show().url)
+    }
+  }
+
+  "Calling the change action of the Capture Agent Email controller without a submitted Email" should {
+    "go to the Capture Agent Email page" in {
+      mockAuthRetrieveAgentEnrolment()
+
+      val result = TestCaptureAgentEmailController.change(testGetRequest)
+
+      status(result) shouldBe Status.SEE_OTHER
+      session(result).get(SessionKeys.transactionEmailKey) shouldBe None
+
+    }
+  }
+
+  "Calling the change action of the Capture Agent Email controller with a submitted Email" should {
+    "go to the Capture Agent Email page" in {
+      mockAuthRetrieveAgentEnrolment()
+      val request = testGetRequest.withSession(SessionKeys.transactionEmailKey -> "test@test.com")
+
+      val result = TestCaptureAgentEmailController.change(request)
+
+      status(result) shouldBe Status.SEE_OTHER
+      session(result).get(SessionKeys.transactionEmailKey) shouldBe None
+
     }
   }
 

--- a/test/uk/gov/hmrc/vatsignupfrontend/views/agent/ConfirmAgentEmailSpec.scala
+++ b/test/uk/gov/hmrc/vatsignupfrontend/views/agent/ConfirmAgentEmailSpec.scala
@@ -58,7 +58,7 @@ class ConfirmAgentEmailSpec extends ViewSpec {
     testPage.shouldHaveALink(
       id = "changeLink",
       text = messages.link,
-      href = uk.gov.hmrc.vatsignupfrontend.controllers.agent.routes.CaptureAgentEmailController.show().url
+      href = uk.gov.hmrc.vatsignupfrontend.controllers.agent.routes.CaptureAgentEmailController.change().url
     )
   }
 


### PR DESCRIPTION
Updated the change email link to hit different route to which removes the agent email from session before directing to the main page