### PR TITLE
SAR-5035 - Allow enrolled registered societies with no CTUTR downstream

### DIFF
--- a/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/ConfirmRegisteredSocietyController.scala
+++ b/app/uk/gov/hmrc/vatsignupfrontend/controllers/principal/ConfirmRegisteredSocietyController.scala
@@ -78,18 +78,18 @@ class ConfirmRegisteredSocietyController @Inject()(val controllerComponents: Con
 
         (optCompanyNumber, optVatNumber) match {
           case (Some(companyNumber), Some(vatNumber)) =>
-            optCtReference match {
-              case Some(_) =>
-                storeRegisteredSociety(vatNumber, companyNumber, optCtReference)
-              case None =>
-                ctReferenceLookupService.checkCtReferenceExists(companyNumber) flatMap {
-                  case Right(CtReferenceIsFound) =>
+            ctReferenceLookupService.checkCtReferenceExists(companyNumber) flatMap {
+              case Right(CtReferenceIsFound) =>
+                optCtReference match {
+                  case Some(_) =>
+                    storeRegisteredSociety(vatNumber, companyNumber, optCtReference)
+                  case None =>
                     Future.successful(Redirect(routes.CaptureRegisteredSocietyUtrController.show()))
-                  case Left(CtReferenceNotFound) =>
-                    storeRegisteredSociety(vatNumber, companyNumber, None)
-                  case Left(CtReferenceLookupFailureResponse(status)) =>
-                    throw new InternalServerException("CtReferenceLookup failed: status = " + status)
                 }
+              case Left(CtReferenceNotFound) =>
+                storeRegisteredSociety(vatNumber, companyNumber, None)
+              case Left(CtReferenceLookupFailureResponse(status)) =>
+                throw new InternalServerException("CtReferenceLookup failed: status = " + status)
             }
           case (_, None) =>
             Future.successful(Redirect(routes.ResolveVatNumberController.resolve()))

--- a/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/ConfirmRegisteredSocietyControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignupfrontend/controllers/principal/ConfirmRegisteredSocietyControllerISpec.scala
@@ -60,7 +60,26 @@ class ConfirmRegisteredSocietyControllerISpec extends ComponentSpecBase with Cus
     "redirect to agree to receive email page" when {
       "the enrolment ctutr matches the retrieved ctutr from DES" in {
         stubAuth(OK, successfulAuthResponse(irctEnrolment))
+        stubCtReferenceFound(testCompanyNumber)
         stubStoreRegisteredSocietySuccess(testVatNumber, testCompanyNumber, Some(testCtUtr))
+
+        val res = post("/confirm-registered-society",
+          Map(
+            SessionKeys.vatNumberKey -> testVatNumber,
+            SessionKeys.registeredSocietyCompanyNumberKey -> testCompanyNumber
+          ))()
+
+        res should have(
+          httpStatus(SEE_OTHER),
+          redirectUri(routes.DirectDebitResolverController.show().url)
+        )
+      }
+    }
+    "redirect to agree to receive email page" when {
+      "the user has an enrolment, but none exists on the backend" in {
+        stubAuth(OK, successfulAuthResponse(irctEnrolment))
+        stubCtReferenceNotFound(testCompanyNumber)
+        stubStoreRegisteredSocietySuccess(testVatNumber, testCompanyNumber, None)
 
         val res = post("/confirm-registered-society",
           Map(
@@ -77,6 +96,7 @@ class ConfirmRegisteredSocietyControllerISpec extends ComponentSpecBase with Cus
     "redirect to capture registered society utr" when {
       "the ctutr does not match the enrolment ctutr" in {
         stubAuth(OK, successfulAuthResponse(irctEnrolment))
+        stubCtReferenceFound(testCompanyNumber)
         stubStoreRegisteredSocietyCtMismatch(testVatNumber, testCompanyNumber, Some(testCtUtr))
 
         val res = post("/confirm-registered-society",


### PR DESCRIPTION
Update submit method of ConfirmRegisteredSocietyController to check if CTUTR exists before storing it when a user has an IR-CT enrolment.

Also fixed up the existing unit tests a bit.